### PR TITLE
:lipstick: style: Reduce welcome page catchphrase size from `lg` to `sm`

### DIFF
--- a/src/pages/WelcomePage.tsx
+++ b/src/pages/WelcomePage.tsx
@@ -85,7 +85,7 @@ export default function WelcomePage() {
         />
         <div className="relative z-10">
           <h1 className="mb-4 text-3xl font-bold">Welcome to Inkless DB</h1>
-          <p className="text-muted-foreground text-lg italic">
+          <p className="text-muted-foreground text-sm italic">
             Manage your databases without writing queries.
           </p>
         </div>


### PR DESCRIPTION
## Description
This pull request adjusts the font size of the welcome page catchphrase from **large (`lg`)** to **small (`sm`)** in order to achieve a subtler, more refined visual hierarchy.  
The change aligns the supporting text with modern UI conventions, ensuring the main heading retains visual prominence.

## Changes
- Updated catchphrase text size: `text-lg` → `text-sm`
- Maintained italic styling and muted foreground colour for consistency

## Rationale
Reducing the size improves readability, maintains a balanced layout, and enhances the overall elegance of the hero section without impacting accessibility.