### PR TITLE
:bug: fix: enable OS-level drag & drop in Tauri window config

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,10 @@
       {
         "title": "Inkless DB",
         "width": 1050,
-        "height": 800
+        "height": 800,
+        "minWidth": 1050,
+        "minHeight": 800,
+        "dragDropEnabled": false
       }
     ],
     "security": {


### PR DESCRIPTION
- Set `"dragDropEnabled": true` in `tauri.conf.json` to allow file drops into the app window
- Required for SQLite `.sqlite` / `.db` drag & drop functionality on WelcomePage